### PR TITLE
made require statement independently from include path

### DIFF
--- a/tests/persistent_session_identity_decorator/test_case.php
+++ b/tests/persistent_session_identity_decorator/test_case.php
@@ -25,7 +25,7 @@
  * @subpackage Tests
  */
 
-require_once 'PersistentObject/tests/persistent_session/test_case.php';
+require_once dirname(__FILE__) . '/../persistent_session/test_case.php';
 
 /**
  * Tests the code manager.


### PR DESCRIPTION
This class relies on the fact that zetaComponents were installed by PEAR or are directly accessible from the include path. This was fixed and the implementation in this directories are used now.
