### PR TITLE
Improved property existence check and tests

### DIFF
--- a/src/handlers/save_handler.php
+++ b/src/handlers/save_handler.php
@@ -539,7 +539,7 @@ class ezcPersistentSaveHandler extends ezcPersistentSessionHandler
             }
             else
             {
-                if ( !array_key_exists( $name, $def->properties ) )
+                if ( !$def->properties->offsetExists( $name ) )
                 {
                     // Unknown property
                     continue;

--- a/tests/keyword_test.php
+++ b/tests/keyword_test.php
@@ -244,7 +244,7 @@ class ezcPersistentKeywordTest extends ezcTestCase
         $this->session->save( $rel );
 
         $this->session->addRelatedObject( $object, $rel );
-        $this->assertNotEquals( count( $this->session->getRelatedObject( $object, "Like" ) ), 0 );
+        $this->assertInstanceOf('Like', $this->session->getRelatedObject( $object, "Like" ));
     }
 
     public function testNMgetRelatedObjects()

--- a/tests/string_identifier_test.php
+++ b/tests/string_identifier_test.php
@@ -254,7 +254,7 @@ class ezcPersistentStringIdentifierTest extends ezcTestCase
         $this->session->save( $rel );
 
         $this->session->addRelatedObject( $object, $rel );
-        $this->assertNotEquals( count( $this->session->getRelatedObject( $object, "Rel2" ) ), 0 );
+        $this->assertInstanceOf('Rel2', $this->session->getRelatedObject( $object, "Rel2" ));
     }
 
     public function testNMgetRelatedObjects()


### PR DESCRIPTION
`$def->properties` is a object type of `ezcPersistentObjectProperties` and extends `ArrayAccess`.
`array_key_exists` should not be used on objects and is deprecated since php 7.4.0 and works only for backward compatibility reasons.

> Additionally, the fact that array_key_exists() accepts objects may mistakenly lead users to believe that it can operate on ArrayAccess objects in a sensible manner. This is not the case: array_key_exists() has no support for ArrayAccess, it exclusively works on mangled object properties.
https://wiki.php.net/rfc/deprecations_php_7_4#array_key_exists_with_objects


I also fixed two tests. In php 7.4. you must implement explicit Countable on Objects.
php 7.4
```php
php > $foo = new \StdClass;
php > var_dump(count($foo));
Warning: count(): Parameter must be an array or an object that implements Countable in php shell code on line 1 
```
php 5.4
```php
php > $foo = new \StdClass;
php > var_dump(count($foo));
php shell code:1:
int(1)
```